### PR TITLE
Changed order of plots on html output to alphabetical

### DIFF
--- a/analyzeModule.py
+++ b/analyzeModule.py
@@ -346,10 +346,9 @@ if __name__ == "__main__":
     plots = []
 
     for mod in modules:
-        plots = glob.glob(outdir + "/" + mod +"/*" + postfix)
+        plots = sorted(glob.glob(outdir + "/" + mod +"/*" + postfix))
         plots = [ x.replace(outdir + "/", "") for x in plots ]
-        
+
         HtmlMod(mod, plots)
 
     HtmlIndex(modules)
-


### PR DESCRIPTION
Da hattest du mich am Anfang mal danach gefragt..
Jetzt sind immerhin die Plots zusammen, die zusammengehoeren. Auf Ueberschriften etc verzichten wir besser, sonst wird das extrem hardgecodet.
